### PR TITLE
Development

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
     "test": "npm run eslint && npm run mocha",
     "eslint": "eslint src/. test/. --config .eslintrc.json --fix",
     "start": "node src/",
-    "mocha": "mocha test/ --recursive --exit"
+    "mocha": "mocha test/ --harmony --recursive --exit"
   },
   "dependencies": {
     "@feathersjs/authentication": "^2.1.6",


### PR DESCRIPTION
When running scripts/test-dependencies.sh, the server tests failed because mocha doesn't recognize object destructuring. I added the --harmony flag and this seems to work.